### PR TITLE
指定ユーザ詳細取得機能 (GET /users/{user_id})

### DIFF
--- a/.docs/swagger/openapi.yml
+++ b/.docs/swagger/openapi.yml
@@ -378,7 +378,7 @@ components:
       properties:
         result:
           $ref: '#/components/schemas/result'
-        tweet:
+        user:
           $ref: '#/components/schemas/user'
       required:
         - result

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\User\ShowResource;
+use App\Models\User;
+use App\UseCases\User\ShowAction;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    /**
+     * @param User $user
+     * @param ShowAction $action
+     *
+     * @return ShowResource
+     */
+    public function show(User $user, ShowAction $action): ShowResource
+    {
+        return new ShowResource($action($user));
+    }
+}

--- a/app/Http/Resources/User/ShowResource.php
+++ b/app/Http/Resources/User/ShowResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources\User;
+
+use App\Http\Resources\Tweet\TweetInfoResource;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ShowResource extends JsonResource
+{
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     *
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'result' => true,
+            'user' => [
+                'user_id' => $this->id,
+                'user_name' => $this->name,
+                'tweets' => TweetInfoResource::collection($this->tweets),
+                'liked_tweets' => TweetInfoResource::collection($this->likedTweets),
+            ],
+        ];
+    }
+}

--- a/app/UseCases/User/ShowAction.php
+++ b/app/UseCases/User/ShowAction.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace App\UseCases\User;
+
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+
+class ShowAction
+{
+    public function __invoke(User $user): User
+    {
+        return $user;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\TweetController;
+use App\Http\Controllers\UserController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -19,6 +20,8 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/users/{user}', [UserController::class, 'show']);
 
 Route::get('/tweets', [TweetController::class, 'index']);
 Route::post('/tweets', [TweetController::class, 'store'])->middleware('auth:sanctum');

--- a/tests/Feature/User/GetUsersUseridTest.php
+++ b/tests/Feature/User/GetUsersUseridTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class GetUsersUseridTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $exist_id;
+    private $nonexistent_id;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+
+        $this->exist_id = User::first()->id;
+        $this->nonexistent_id = User::orderBy('id', 'DESC')->first()->id + 1;
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 指定ユーザ取得成功(): void
+    {
+        $response = $this->get('api/users/'.$this->exist_id);
+
+        $response
+            ->assertStatus(200)
+            ->assertJsonFragment([
+                'result' => true
+            ])
+            ->assertJsonStructure([
+                'result',
+                'user' => [
+                    'user_id',
+                    'user_name',
+                    'tweets',
+                    'liked_tweets'
+                ]
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 取得失敗_存在しないユーザID(): void
+    {
+        $response = $this->get('api/users/'.$this->nonexistent_id);
+
+        $response
+            ->assertStatus(404);
+    }
+
+}


### PR DESCRIPTION
## PR

issue #11 

### やったこと

- swagger レスポンスの誤り修正
- テスト作成
- ルート作成
- コントローラメソッド作成
- ユースケース作成
- レスポンスリソース作成

### できるようになること（ユーザ目線）

- 指定ユーザの詳細情報が取得できる

### できなくなること（ユーザ目線）

- なし

### テスト

- 200
- 404

### 備考

- 
