### PR TITLE
いいね付与・削除機能 (/like)

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,8 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -37,5 +39,18 @@ class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e) {
             //
         });
+    }
+
+    public function render($request, Throwable $exception)
+    {
+        // 400
+        if ($exception instanceof BadRequestException) {
+            return response()->json([
+                'result' => false,
+                'message' => $exception->getMessage(),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        return parent::render($request, $exception);
     }
 }

--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Like\StoreRequest;
+use App\Http\Resources\Like\StoreResource;
+use App\UseCases\Like\StoreAction;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+
+class LikeController extends Controller
+{
+    /**
+     * @param StoreRequest $request
+     * @param StoreAction $action
+     *
+     * @return StoreResource
+     */
+    public function store(StoreRequest $request, StoreAction $action): StoreResource
+    {
+        try {
+            return new StoreResource(
+                $action(
+                    $request->user(),
+                    $request->tweet_id,
+                )
+            );
+        } catch (BadRequestException $e) {
+            throw new BadRequestException($e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Like\DestroyRequest;
 use App\Http\Requests\Like\StoreRequest;
+use App\Http\Resources\Like\DestroyResource;
 use App\Http\Resources\Like\StoreResource;
+use App\UseCases\Like\DestroyAction;
 use App\UseCases\Like\StoreAction;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
@@ -20,6 +23,26 @@ class LikeController extends Controller
     {
         try {
             return new StoreResource(
+                $action(
+                    $request->user(),
+                    $request->tweet_id,
+                )
+            );
+        } catch (BadRequestException $e) {
+            throw new BadRequestException($e->getMessage());
+        }
+    }
+
+    /**
+     * @param DestroyRequest $request
+     * @param DestroyAction $action
+     *
+     * @return DestroyResource
+     */
+    public function destroy(DestroyRequest $request, DestroyAction $action): DestroyResource
+    {
+        try {
+            return new DestroyResource(
                 $action(
                     $request->user(),
                     $request->tweet_id,

--- a/app/Http/Requests/Like/DestroyRequest.php
+++ b/app/Http/Requests/Like/DestroyRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Like;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Symfony\Component\HttpFoundation\Response;
+
+class DestroyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'tweet_id' => 'required|exists:tweets,id',
+        ];
+    }
+
+    /**
+     * @param Validator $validator
+     *
+     * @return Response
+     */
+    protected function failedValidation(Validator $validator): Response
+    {
+        $res = response()->json([
+            'result' => false,
+            'errors' => $validator->errors(),
+        ], Response::HTTP_BAD_REQUEST);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/Like/StoreRequest.php
+++ b/app/Http/Requests/Like/StoreRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Like;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Symfony\Component\HttpFoundation\Response;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'tweet_id' => 'required|exists:tweets,id',
+        ];
+    }
+
+    /**
+     * @param Validator $validator
+     *
+     * @return Response
+     */
+    protected function failedValidation(Validator $validator): Response
+    {
+        $res = response()->json([
+            'result' => false,
+            'errors' => $validator->errors(),
+        ], Response::HTTP_BAD_REQUEST);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Resources/Like/DestroyResource.php
+++ b/app/Http/Resources/Like/DestroyResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\Like;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DestroyResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'result' => true,
+        ];
+    }
+}

--- a/app/Http/Resources/Like/StoreResource.php
+++ b/app/Http/Resources/Like/StoreResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\Like;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StoreResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'result' => true,
+        ];
+    }
+}

--- a/app/UseCases/Like/DestroyAction.php
+++ b/app/UseCases/Like/DestroyAction.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace App\UseCases\Like;
+
+
+use App\Models\Like;
+use App\Models\Tweet;
+use App\Models\User;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+
+class DestroyAction
+{
+    public function __invoke(User $user, Int $tweet_id)
+    {
+        $tweet = Tweet::find($tweet_id);
+
+        if (!$tweet->isLiked($user)) {
+            throw new BadRequestException('The tweet with the tweet_id has not been liked yet.');
+        }
+
+        $user->likedTweets()->detach($tweet_id);
+
+        return;
+    }
+}

--- a/app/UseCases/Like/StoreAction.php
+++ b/app/UseCases/Like/StoreAction.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace App\UseCases\Like;
+
+
+use App\Models\Like;
+use App\Models\Tweet;
+use App\Models\User;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+
+class StoreAction
+{
+    public function __invoke(User $user, Int $tweet_id): Like
+    {
+        $tweet = Tweet::find($tweet_id);
+
+        if ($tweet->isLiked($user)) {
+            throw new BadRequestException('The tweet with the tweet_id has already been liked.');
+        }
+
+        $like = Like::create([
+            'user_id' => $user->id,
+            'tweet_id' => $tweet->id,
+        ]);
+
+        return $like;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -174,7 +174,6 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
-
     ],
 
     /*

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\LikeController;
 use App\Http\Controllers\TweetController;
 use App\Http\Controllers\UserController;
 use Illuminate\Http\Request;
@@ -25,6 +26,8 @@ Route::get('/users/{user}', [UserController::class, 'show']);
 
 Route::get('/tweets', [TweetController::class, 'index']);
 Route::post('/tweets', [TweetController::class, 'store'])->middleware('auth:sanctum');
+
+Route::post('/like', [LikeController::class, 'store'])->middleware('auth:sanctum');
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ Route::get('/tweets', [TweetController::class, 'index']);
 Route::post('/tweets', [TweetController::class, 'store'])->middleware('auth:sanctum');
 
 Route::post('/like', [LikeController::class, 'store'])->middleware('auth:sanctum');
+Route::delete('/like', [LikeController::class, 'destroy'])->middleware('auth:sanctum');
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);

--- a/tests/Feature/Like/DeleteLikeTest.php
+++ b/tests/Feature/Like/DeleteLikeTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature\Like;
+
+use App\Models\Tweet;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DeleteLikeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    const MAX_CONTENT_LENGTH = 140;
+
+    private $login_user;
+    private $liked_tweet_id;
+    private $nonexistent_tweet_id;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+
+        $this->login_user = User::first();
+        $this->liked_tweet_id = $this->login_user->likedTweets->first()->id;
+        $this->nonexistent_tweet_id = Tweet::orderBy('id', 'DESC')->first()->id + 1;
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function いいね削除成功(): void
+    {
+        $response = $this
+            ->actingAs($this->login_user)
+            ->delete('api/like', [
+                'tweet_id' => $this->liked_tweet_id,
+            ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertExactJson([
+                'result' => true
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 削除失敗_未付与ツイート対象(): void
+    {
+        $new_tweet = Tweet::create([
+            'user_id' => $this->login_user->id,
+            'content' => 'test tweet',
+        ]);
+
+        $response = $this
+            ->actingAs($this->login_user)
+            ->delete('api/like', [
+                'tweet_id' => $new_tweet->id,
+            ]);
+
+        $response
+            ->assertStatus(400)
+            ->assertExactJson([
+                'result' => false,
+                'message' => 'The tweet with the tweet_id has not been liked yet.',
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 削除失敗_未認証(): void
+    {
+        $response = $this
+            ->delete('api/like', [
+                'tweet_id' => $this->liked_tweet_id,
+            ]);
+
+        $response
+            ->assertStatus(500);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function バリデーションエラー_必須項目無し(): void
+    {
+        $response = $this
+            ->actingAs($this->login_user)
+            ->delete('api/like');
+
+        $response
+            ->assertStatus(400)
+            ->assertExactJson([
+                'result' => false,
+                'errors' => [
+                    'tweet_id' => [
+                        'The tweet id field is required.'
+                    ]
+                ]
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function バリデーションエラー_tweetId_存在しないID(): void
+    {
+        $response = $this
+            ->actingAs($this->login_user)
+            ->delete('api/like', [
+                'tweet_id' => $this->nonexistent_tweet_id,
+            ]);
+
+        $response
+            ->assertStatus(400)
+            ->assertExactJson([
+                'result' => false,
+                'errors' => [
+                    'tweet_id' => [
+                        'The selected tweet id is invalid.'
+                    ]
+                ]
+            ]);
+    }
+
+}

--- a/tests/Feature/Like/PostLikeTest.php
+++ b/tests/Feature/Like/PostLikeTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature\Like;
+
+use App\Models\Tweet;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class PostLikeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    const MAX_CONTENT_LENGTH = 140;
+
+    private $login_user;
+    private $liked_tweet_id;
+    private $nonexistent_tweet_id;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+
+        $this->login_user = User::first();
+        $this->liked_tweet_id = $this->login_user->likedTweets->first()->id;
+        $this->nonexistent_tweet_id = Tweet::orderBy('id', 'DESC')->first()->id + 1;
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function いいね付与成功(): void
+    {
+        $new_tweet = Tweet::create([
+            'user_id' => $this->login_user->id,
+            'content' => 'test tweet',
+        ]);
+
+        $response = $this
+            ->actingAs($this->login_user)
+            ->post('api/like', [
+                'tweet_id' => $new_tweet->id,
+            ]);
+
+        $response
+            ->assertStatus(201)
+            ->assertExactJson([
+                'result' => true
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 付与失敗_既付与ツイート対象(): void
+    {
+        $response = $this
+            ->actingAs($this->login_user)
+            ->post('api/like', [
+                'tweet_id' => $this->liked_tweet_id,
+            ]);
+
+        $response
+            ->assertStatus(400)
+            ->assertExactJson([
+                'result' => false,
+                'message' => 'The tweet with the tweet_id has already been liked.',
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 付与失敗_未認証(): void
+    {
+        $new_tweet = Tweet::create([
+            'user_id' => $this->login_user->id,
+            'content' => 'test tweet',
+        ]);
+
+        $response = $this
+            ->post('api/like', [
+                'tweet_id' => $new_tweet->id,
+            ]);
+
+        $response
+            ->assertStatus(500);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function バリデーションエラー_必須項目無し(): void
+    {
+        $response = $this
+            ->actingAs($this->login_user)
+            ->post('api/like');
+
+        $response
+            ->assertStatus(400)
+            ->assertExactJson([
+                'result' => false,
+                'errors' => [
+                    'tweet_id' => [
+                        'The tweet id field is required.'
+                    ]
+                ]
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function バリデーションエラー_tweetId_存在しないID(): void
+    {
+        $response = $this
+            ->actingAs($this->login_user)
+            ->post('api/like', [
+                'tweet_id' => $this->nonexistent_tweet_id,
+            ]);
+
+        $response
+            ->assertStatus(400)
+            ->assertExactJson([
+                'result' => false,
+                'errors' => [
+                    'tweet_id' => [
+                        'The selected tweet id is invalid.'
+                    ]
+                ]
+            ]);
+    }
+
+}


### PR DESCRIPTION
## PR

issue #9 

### やったこと

- テスト作成
- ルート作成
- コントローラメソッド作成
- ユースケース作成
- レスポンスリソース作成
- 例外用レスポンス作成

### できるようになること（ユーザ目線）

- ログインユーザで指定ツイートのいいね付与ができる
- ログインユーザで指定ツイートのいいね削除ができる

### できなくなること（ユーザ目線）

- なし

### テスト

- 200
- 失敗
  - 既いいね/未いいね
  - 未認証
- バリデーションエラー
  - 必須項目
  - 存在しないtweet_id

### 備考

- exception
  - 参考 : https://zenn.dev/naoki_oshiumi/articles/f26e8a4fea92e7
