### PR TITLE
指定ツイート取得・削除 機能 (GET DELETE/tweets/{tweet_id})

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,6 +2,7 @@
 
 namespace App\Exceptions;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,6 +50,14 @@ class Handler extends ExceptionHandler
                 'result' => false,
                 'message' => $exception->getMessage(),
             ], Response::HTTP_BAD_REQUEST);
+        }
+
+        // 404
+        if ($exception instanceof ModelNotFoundException) {
+            return response()->json([
+                'result' => false,
+                'message' => 'The specified id does not exist.',
+            ], Response::HTTP_NOT_FOUND);
         }
 
         return parent::render($request, $exception);

--- a/app/Http/Controllers/TweetController.php
+++ b/app/Http/Controllers/TweetController.php
@@ -3,14 +3,17 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Tweet\StoreRequest;
+use App\Http\Resources\Tweet\DestroyResource;
 use App\Http\Resources\Tweet\IndexResource;
 use App\Http\Resources\Tweet\StoreResource;
 use App\Http\Resources\Tweet\ShowResource;
 use App\Models\Tweet;
+use App\UseCases\Tweet\DestroyAction;
 use App\UseCases\Tweet\IndexAction;
 use App\UseCases\Tweet\ShowAction;
 use App\UseCases\Tweet\StoreAction;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 
 class TweetController extends Controller
 {
@@ -50,5 +53,26 @@ class TweetController extends Controller
     public function show(Tweet $tweet, ShowAction $action): ShowResource
     {
         return new ShowResource($action($tweet));
+    }
+
+    /**
+     * @param Request $request
+     * @param Tweet $tweet
+     * @param DestroyAction $action
+     *
+     * @return DestroyResource
+     */
+    public function destroy(Request $request, Tweet $tweet, DestroyAction $action): DestroyResource
+    {
+        try {
+            return new DestroyResource(
+                $action(
+                    $request->user(),
+                    $tweet,
+                )
+            );
+        } catch (BadRequestException $e) {
+            throw $e;
+        }
     }
 }

--- a/app/Http/Controllers/TweetController.php
+++ b/app/Http/Controllers/TweetController.php
@@ -5,7 +5,10 @@ namespace App\Http\Controllers;
 use App\Http\Requests\Tweet\StoreRequest;
 use App\Http\Resources\Tweet\IndexResource;
 use App\Http\Resources\Tweet\StoreResource;
+use App\Http\Resources\Tweet\ShowResource;
+use App\Models\Tweet;
 use App\UseCases\Tweet\IndexAction;
+use App\UseCases\Tweet\ShowAction;
 use App\UseCases\Tweet\StoreAction;
 use Illuminate\Http\Request;
 
@@ -36,5 +39,16 @@ class TweetController extends Controller
                 $request->content
             )
         );
+    }
+
+    /**
+     * @param Tweet $tweet
+     * @param ShowAction $action
+     *
+     * @return ShowResource
+     */
+    public function show(Tweet $tweet, ShowAction $action): ShowResource
+    {
+        return new ShowResource($action($tweet));
     }
 }

--- a/app/Http/Resources/Tweet/DestroyResource.php
+++ b/app/Http/Resources/Tweet/DestroyResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\Tweet;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DestroyResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'result' => true,
+        ];
+    }
+}

--- a/app/Http/Resources/Tweet/ShowResource.php
+++ b/app/Http/Resources/Tweet/ShowResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources\Tweet;
+
+use App\Http\Resources\User\UserInfoResource;
+use Carbon\Carbon;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ShowResource extends JsonResource
+{
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     *
+     * @return array
+     */
+    public function toArray($request)
+    {
+        $tweet_at = new Carbon($this->created_at);
+        return [
+            'result' => true,
+            'tweet' => [
+                'tweet_id' => $this->id,
+                'user_name' => $this->user->name,
+                'content' => $this->content,
+                'liked_users' => UserInfoResource::collection($this->likedUsers),
+                'date' => ($tweet_at)->format('Y-m-d H:i:s'),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/User/UserInfoResource.php
+++ b/app/Http/Resources/User/UserInfoResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\User;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserInfoResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'user_id' => $this->id,
+            'user_name' => $this->name,
+        ];
+    }
+}

--- a/app/UseCases/Tweet/DestroyAction.php
+++ b/app/UseCases/Tweet/DestroyAction.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace App\UseCases\Tweet;
+
+
+use App\Models\Like;
+use App\Models\Tweet;
+use App\Models\User;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+
+class DestroyAction
+{
+    public function __invoke(User $user, Tweet $tweet)
+    {
+        if ($user->id !== $tweet->user_id) {
+            throw new BadRequestException('The tweet with the tweet_id is not owned by the login user.');
+        }
+
+        $tweet->delete();
+
+        return;
+    }
+}

--- a/app/UseCases/Tweet/ShowAction.php
+++ b/app/UseCases/Tweet/ShowAction.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace App\UseCases\Tweet;
+
+
+use App\Models\Tweet;
+use Illuminate\Database\Eloquent\Collection;
+
+class ShowAction
+{
+    public function __invoke(Tweet $tweet): Tweet
+    {
+        return $tweet;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ Route::get('/users/{user}', [UserController::class, 'show']);
 
 Route::get('/tweets', [TweetController::class, 'index']);
 Route::post('/tweets', [TweetController::class, 'store'])->middleware('auth:sanctum');
+Route::get('/tweets/{tweet}', [TweetController::class, 'show']);
 
 Route::post('/like', [LikeController::class, 'store'])->middleware('auth:sanctum');
 Route::delete('/like', [LikeController::class, 'destroy'])->middleware('auth:sanctum');

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,7 @@ Route::get('/users/{user}', [UserController::class, 'show']);
 Route::get('/tweets', [TweetController::class, 'index']);
 Route::post('/tweets', [TweetController::class, 'store'])->middleware('auth:sanctum');
 Route::get('/tweets/{tweet}', [TweetController::class, 'show']);
+Route::delete('/tweets/{tweet}', [TweetController::class, 'destroy'])->middleware('auth:sanctum');
 
 Route::post('/like', [LikeController::class, 'store'])->middleware('auth:sanctum');
 Route::delete('/like', [LikeController::class, 'destroy'])->middleware('auth:sanctum');

--- a/tests/Feature/Tweet/DeleteTweetsTweetidTest.php
+++ b/tests/Feature/Tweet/DeleteTweetsTweetidTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Tweet;
+
+use App\Models\Tweet;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DeleteTweetsTweetidTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $login_user;
+    private $other_user;
+    private $exist_tweet_id;
+    private $nonexistent_tweet_id;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+
+        $this->login_user = User::first();
+        $this->other_user = User::orderBy('id', 'DESC')->first();
+        $this->exist_tweet_id = Tweet::first()->id + 1;
+        $this->nonexistent_tweet_id = Tweet::orderBy('id', 'DESC')->first()->id + 1;
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 指定ツイート削除成功(): void
+    {
+        $tweet_by_login_user = Tweet::create([
+            'user_id' => $this->login_user->id,
+            'content' => 'test tweet',
+        ]);
+
+        $response = $this
+            ->actingAs($this->login_user)
+            ->delete('api/tweets/'.$tweet_by_login_user->id);
+
+        $response
+            ->assertStatus(200)
+            ->assertExactJson([
+                'result' => true,
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 削除失敗_未認証(): void
+    {
+        $response = $this
+            ->delete('api/tweets/'.$this->exist_tweet_id);
+
+        $response
+            ->assertStatus(500);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 削除失敗_未所持ツイート(): void
+    {
+        $tweet_by_other_user = Tweet::create([
+            'user_id' => $this->other_user->id,
+            'content' => 'test tweet',
+        ]);
+
+        $response = $this
+            ->actingAs($this->login_user)
+            ->delete('api/tweets/'.$tweet_by_other_user->id);
+
+        $response
+            ->assertStatus(400)
+            ->assertExactJson([
+                'result' => false,
+                'message' => 'The tweet with the tweet_id is not owned by the login user.',
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 削除失敗_存在しないツイートID(): void
+    {
+        $response = $this
+            ->actingAs($this->login_user)
+            ->delete('api/tweets/'.$this->nonexistent_tweet_id);
+
+        $response
+            ->assertStatus(404)
+            ->assertExactJson([
+                'result' => false,
+                'message' => 'The specified id does not exist.',
+            ]);
+    }
+
+}

--- a/tests/Feature/Tweet/GetTweetsTweetidTest.php
+++ b/tests/Feature/Tweet/GetTweetsTweetidTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Tweet;
+
+use App\Models\Tweet;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class GetTweetsTweetidTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $exist_tweet_id;
+    private $nonexistent_tweet_id;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+
+        $this->exist_tweet_id = Tweet::all()->first()->id;
+        $this->nonexistent_tweet_id = Tweet::orderBy('id', 'DESC')->first()->id + 1;
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 指定ツイート取得成功(): void
+    {
+        $response = $this->get('api/tweets/'.$this->exist_tweet_id);
+
+        $response
+            ->assertStatus(200)
+            ->assertJsonFragment([
+                'result' => true
+            ])
+            ->assertJsonStructure([
+                'result',
+                'tweet' => [
+                    'tweet_id',
+                    'user_name',
+                    'content',
+                    'liked_users',
+                    'date',
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function 取得失敗_存在しないツイートID(): void
+    {
+        $response = $this->get('api/tweets/'.$this->nonexistent_tweet_id);
+
+        $response
+            ->assertStatus(404)
+            ->assertExactJson([
+                'result' => false,
+                'message' => 'The specified id does not exist.',
+            ]);
+    }
+
+}


### PR DESCRIPTION
## PR

issue #10 

### やったこと

- テスト作成
- ルート作成
- 機能作成
  - GET
    - コントローラメソッド
    - アクション
    - リソース
  - DELETE
    - コントローラメソッド
    - アクション
    - リソース
- テスト確認
- 404エラーレスポンス作成

### できるようになること（ユーザ目線）

- 指定ツイートの詳細情報を取得できる
- ログインユーザが自身の指定ツイートを削除することができる

### できなくなること（ユーザ目線）

- なし

### テスト

- GET
  - 成功
  - 404
- DELETE
  - 成功
  - 未認証
  - 自身のツイートでない
  - 404

### 備考

- 404 error response
  - 参考 : https://techhacknote.com/laravel-api-404-json-response/
